### PR TITLE
Fix typo in vertical menu header on mobile nav

### DIFF
--- a/views/header.phtml
+++ b/views/header.phtml
@@ -34,7 +34,7 @@
 	  <div class="main_container">
     <!-- Mobile Menu -->
     <div class="mobilenav">
-      <a href="index.php" class="mobilelogo"><i class="fa fa-btc" style="color:orange"></i> Bitcoin Node Manger</a>
+      <a href="index.php" class="mobilelogo"><i class="fa fa-btc" style="color:orange"></i> Bitcoin Node Manager</a>
       <div id="mobileLinks">
         <a href="?p=peers"><i class="fa fa-list"></i> Peers </a>
         <a href="?p=rules"><i class="fa fa-file-text-o"></i> Rules </a>


### PR DESCRIPTION
"Manager" was misspelled as "Manger"