### PR TITLE
Handle bitcoind not returning softforks data

### DIFF
--- a/src/Node.php
+++ b/src/Node.php
@@ -141,6 +141,10 @@ class Node {
 		$this->hashRate = round(checkInt($miningInfo["networkhashps"])/1000000000000000000,3);
 		$this->mNetTime = getDateTime($blockchainInfo["mediantime"]);
 		// Blockchain -> Soft forks
-		$this->softForks = checkSoftFork($blockchainInfo["softforks"]);		
+		if(isset($blockchainInfo["softforks"])) {
+            		$this->softForks = checkSoftFork($blockchainInfo["softforks"]);
+        	} else {
+            		$this->softForks = [];
+        	}
 	}
 }


### PR DESCRIPTION
Get rid of the below warning in the page header when bitcoind doesn't return the softforks key.

```
Warning: Undefined array key "softforks" in /config/www/src/Node.php on line 145

Warning: foreach() argument must be of type array|object, null given in /config/www/src/Utility.php on line 253
```