### PR TITLE
Update error message for wallet

### DIFF
--- a/src/Content.php
+++ b/src/Content.php
@@ -228,7 +228,7 @@ function createWalletContent(){
 		$balances = $bitcoind->getbalances();
 	}catch(\Exception $e){
 		if ($e->getCode() == -18) {
-			$error = "Invalid wallet specified!";
+			$error = "Wallet data not found.";
 		} else {
 			$error = "Wallet disabled!";
 		}


### PR DESCRIPTION
This updates the RPC_WALLET_NOT_FOUND error message to be less confusing for the user.

Here is the end result:
<img width="558" alt="Screenshot 2023-08-09 at 09 54 30" src="https://github.com/Mirobit/bitcoin-node-manager/assets/3606313/efbbf10a-a70d-446a-b5de-0dbd03ca238d">
